### PR TITLE
 deps: upgrade phoenix_html and add phoenix_html_helpers #68 

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,9 @@ def view do
 
     import Phoenix.Controller, only: [get_flash: 1, get_flash: 2, view_module: 1]
 
-    use Phoenix.HTML
+    import Phoenix.HTML
+    import Phoenix.HTML.Form
+    use PhoenixHTMLHelpers
 
     import MyPhoenixApp.ErrorHelpers
     import MyPhoenixApp.Gettext

--- a/lib/react_phoenix/client_side.ex
+++ b/lib/react_phoenix/client_side.ex
@@ -9,7 +9,7 @@ defmodule ReactPhoenix.ClientSide do
   switching over to a different system.
   """
 
-  import Phoenix.HTML.Tag
+  use PhoenixHTMLHelpers
 
   @doc """
   Generate a div containing the named React component with no props or options.

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule ReactPhoenix.Mixfile do
     [
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:dialyxir, ">= 0.5.0", only: :dev},
-      {:phoenix_html, "~> 2.11 or ~> 3.0"},
+      {:phoenix_html, "~> 4.0"},
+      {:phoenix_html_helpers, "~> 1.0"},
       {:jason, "~> 1.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -10,7 +10,8 @@
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.0", "b44d75e2a6542dcb6acf5d71c32c74ca88960421b6874777f79153bbbbd7dccc", [:mix], [], "hexpm", "52b2871a7515a5ac49b00f214e4165a40724cf99798d8e4a65e4fd64ebd002c1"},
-  "phoenix_html": {:hex, :phoenix_html, "3.1.0", "0b499df05aad27160d697a9362f0e89fa0e24d3c7a9065c2bd9d38b4d1416c09", [:mix], [{:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm", "0c0a98a2cefa63433657983a2a594c7dee5927e4391e0f1bfd3a151d1def33fc"},
+  "phoenix_html": {:hex, :phoenix_html, "4.1.1", "4c064fd3873d12ebb1388425a8f2a19348cef56e7289e1998e2d2fa758aa982e", [:mix], [], "hexpm", "f2f2df5a72bc9a2f510b21497fd7d2b86d932ec0598f0210fed4114adc546c6f"},
+  "phoenix_html_helpers": {:hex, :phoenix_html_helpers, "1.0.1", "7eed85c52eff80a179391036931791ee5d2f713d76a81d0d2c6ebafe1e11e5ec", [:mix], [{:phoenix_html, "~> 4.0", [hex: :phoenix_html, repo: "hexpm", optional: false]}, {:plug, "~> 1.5", [hex: :plug, repo: "hexpm", optional: true]}], "hexpm", "cffd2385d1fa4f78b04432df69ab8da63dc5cf63e07b713a4dcf36a3740e3090"},
   "plug": {:hex, :plug, "1.7.1", "8516d565fb84a6a8b2ca722e74e2cd25ca0fc9d64f364ec9dbec09d33eb78ccd", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Upstream PR: https://github.com/geolessel/react-phoenix/pull/68

Upgrades to `phoenix_html` to v4+ which moves HTML helpers to `phoenix_html_helpers`.

From [phoenix_html changelog](https://hexdocs.pm/phoenix_html/changelog.html#v4-0-0-2023-12-19): 
> v4.0.0 (2023-12-19)
> 
> This version removes deprecated functionality and moved all HTML helpers to a separate library. HTML Helpers are no longer used in new apps from Phoenix v1.7. Older applications who wish to maintain compatibility, add {:phoenix_html_helpers, "~> 1.0"} to your mix.exs and then replace use Phoenix.HTML in your applications by:
> 
> import Phoenix.HTML
> import Phoenix.HTML.Form
> use PhoenixHTMLHelpers
> 
